### PR TITLE
fix: adapt OIDC callback to Frappe v16 state handling (consume_oauth_…

### DIFF
--- a/oidc_extended/callback.py
+++ b/oidc_extended/callback.py
@@ -4,19 +4,19 @@
 # - https://github.com/castlecraft/microsoft_integration/blob/main/microsoft_integration/callback.py
 
 import json
-import base64
 import requests
 import jwt
 
 import frappe
 import frappe.utils
 from frappe import _ # For translations
+from frappe.utils.oauth import consume_oauth_state
 
 frappe.utils.logger.set_log_level("INFO")
 #frappe.utils.logger.set_log_level("DEBUG")
 
 @frappe.whitelist(allow_guest=True)
-def custom(code: str, state: str | dict):
+def custom(code: str, state: str):
     """Callback for processing the request received after a successful authentication in an identity provider (OIDC provider).
 
     OIDC redirect URL: /api/method/oidc_extended.callback.custom/<provider name>
@@ -26,10 +26,13 @@ def custom(code: str, state: str | dict):
     - Maps groups from the claim of id token to ERPNext roles.
     """
 
-    state = json.loads(base64.b64decode(state).decode("utf-8"))
-
-    if not state or not state["token"]:
-        frappe.respond_as_web_page(_("Invalid request"), _("Token is missing."), http_status_code=417)
+    redirect_to = consume_oauth_state(state)
+    if redirect_to is None:
+        frappe.respond_as_web_page(
+            _("Invalid Request"),
+            _("Your login attempt is invalid or has expired. Please try again."),
+            http_status_code=417,
+        )
         return
 
     request_path_components = frappe.request.path[1:].split("/")
@@ -210,7 +213,7 @@ def custom(code: str, state: str | dict):
 
     redirect_post_login(
         desk_user=frappe.local.response.get("message") == "Logged In",
-        redirect_to=state.get("redirect_to")
+        redirect_to=redirect_to,
     )
 
 def redirect_post_login(desk_user: bool, redirect_to: str):


### PR DESCRIPTION
## Problem
After upgrading to **Frappe/ERPNext v16**, the Microsoft 365 / OIDC login via `oidc_extended` fails:

```
File "apps/oidc_extended/oidc_extended/callback.py", line 29, in custom
    state = json.loads(base64.b64decode(state).decode("utf-8"))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf7 in position 0: invalid start byte
```

## Root Cause
Frappe v16 changed OAuth `state` handling in `frappe/utils/oauth.py`:
- `create_oauth_state(redirect_to)` now returns `state = frappe.generate_hash(length=32)` (a plain hex hash, e.g. `96f106bd55d0dc1208d87cba2788b892`) and stores `redirect_to` **server-side in the cache** under `{OAUTH_LOGIN_FLOW_CACHE_PREFIX}:{state}` (TTL 600s).
- `consume_oauth_state(state)` resolves the stored `redirect_to` and invalidates the state (single-use): `None` = unknown/expired, `""` = valid without redirect.
- There is no base64-encoded JSON and no `state["token"]` anymore.

`callback.py` still did `json.loads(base64.b64decode(state).decode("utf-8"))`, which fails on the new hash with the `UnicodeDecodeError` above.

## Change
- Replace the base64/JSON decode and `state["token"]` check with `redirect_to = consume_oauth_state(state)` (called **once**, single-use) and a `None` check for invalid/expired state.
- Reuse the resolved `redirect_to` for the final `redirect_post_login(...)` instead of `state.get("redirect_to")`.
- Remove the now-unused `import base64`; simplify the signature `state: str | dict` → `state: str`.

This matches the native path `frappe.integrations.oauth2_logins` → `frappe.utils.oauth.login_oauth_user`, which also uses `consume_oauth_state(state)`.

## Verification
- Statically verified against the Frappe v16 source (`version-16`, `frappe/utils/oauth.py`).
- `py_compile` passes.
- A live M365 login test was not possible without a real auth flow.
